### PR TITLE
Added reply pagination

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -12,8 +12,8 @@ async function loadMoreComments({state, api}) {
     };
 }
 
-async function loadMoreReplies({state, api, data: comment}) {
-    const data = await api.comments.replies({commentId: comment.id, afterReplyId: comment.replies[comment.replies.length - 1]?.id});
+async function loadMoreReplies({state, api, data: {comment, limit}}) {
+    const data = await api.comments.replies({commentId: comment.id, afterReplyId: comment.replies[comment.replies.length - 1]?.id, limit});
 
     // Note: we store the comments from new to old, and show them in reverse order
     return {
@@ -21,10 +21,7 @@ async function loadMoreReplies({state, api, data: comment}) {
             if (c.id === comment.id) {
                 return {
                     ...comment,
-                    replies: [...comment.replies, ...data.comments],
-                    
-                    // Check if we loaded replies from appendedReplies and remove them if required (we are at the end of pagination in that case)
-                    appendedReplies: comment.appendedReplies?.filter(ar => !data.comments.find(ccc => ccc.id === ar.id))
+                    replies: [...comment.replies, ...data.comments]
                 };
             }
             return c;
@@ -59,7 +56,7 @@ async function addReply({state, api, data: {reply, parent}}) {
             if (c.id === parent.id) {
                 return {
                     ...parent,
-                    appendedReplies: [...(parent.appendedReplies ?? []), comment],
+                    replies: [...parent.replies, comment],
                     count: {
                         ...parent.count,
                         replies: parent.count.replies + 1

--- a/src/actions.js
+++ b/src/actions.js
@@ -12,19 +12,32 @@ async function loadMoreComments({state, api}) {
     };
 }
 
+async function loadMoreReplies({state, api, data: comment}) {
+    const data = await api.comments.replies({commentId: comment.id, afterReplyId: comment.replies[comment.replies.length - 1]?.id});
+
+    // Note: we store the comments from new to old, and show them in reverse order
+    return {
+        comments: state.comments.map((c) => {
+            if (c.id === comment.id) {
+                return {
+                    ...comment,
+                    replies: [...comment.replies, ...data.comments],
+                    
+                    // Check if we loaded replies from appendedReplies and remove them if required (we are at the end of pagination in that case)
+                    appendedReplies: comment.appendedReplies?.filter(ar => !data.comments.find(ccc => ccc.id === ar.id))
+                };
+            }
+            return c;
+        })
+    };
+}
+
 async function addComment({state, api, data: comment}) {
     const data = await api.comments.add({comment});
     comment = data.comments[0];
 
-    // Temporary workaround for missing member relation (bug in API)
-    const commentStructured = {
-        ...comment,
-        member: state.member,
-        replies: []
-    };
-
     return {
-        comments: [commentStructured, ...state.comments],
+        comments: [comment, ...state.comments],
         commentCount: state.commentCount + 1
     };
 }
@@ -36,11 +49,9 @@ async function addReply({state, api, data: {reply, parent}}) {
     const data = await api.comments.add({comment});
     comment = data.comments[0];
 
-    // Temporary workaround for missing member relation (bug in API)
-    comment = {
-        ...comment,
-        member: state.member
-    };
+    // When we add a reply,
+    // it is possible that we didn't load all the replies for the given comment yet.
+    // To fix that, we'll save the reply to a different field that is created locally to differentiate between replies before and after pagination 😅
 
     // Replace the comment in the state with the new one
     return {
@@ -48,7 +59,11 @@ async function addReply({state, api, data: {reply, parent}}) {
             if (c.id === parent.id) {
                 return {
                     ...parent,
-                    replies: [...parent.replies, comment]
+                    appendedReplies: [...(parent.appendedReplies ?? []), comment],
+                    count: {
+                        ...parent.count,
+                        replies: parent.count.replies + 1
+                    }
                 };
             }
             return c;
@@ -133,7 +148,10 @@ async function likeComment({state, api, data: comment}) {
                     return {
                         ...r,
                         liked: true,
-                        likes_count: r.likes_count + 1
+                        count: {
+                            ...r.count,
+                            likes: r.count.likes + 1
+                        }
                     };
                 }
 
@@ -144,8 +162,11 @@ async function likeComment({state, api, data: comment}) {
                 return {
                     ...c,
                     liked: true,
-                    likes_count: c.likes_count + 1,
-                    replies
+                    replies,
+                    count: {
+                        ...c.count,
+                        likes: c.count.likes + 1
+                    }
                 };
             }
 
@@ -173,7 +194,10 @@ async function unlikeComment({state, api, data: comment}) {
                     return {
                         ...r,
                         liked: false,
-                        likes_count: r.likes_count - 1
+                        count: {
+                            ...r.count,
+                            likes: r.count.likes - 1
+                        }
                     };
                 }
 
@@ -184,8 +208,11 @@ async function unlikeComment({state, api, data: comment}) {
                 return {
                     ...c,
                     liked: false,
-                    likes_count: c.likes_count - 1,
-                    replies
+                    replies,
+                    count: {
+                        ...c.count,
+                        likes: c.count.likes - 1
+                    }
                 };
             }
             return {
@@ -322,6 +349,7 @@ const Actions = {
     reportComment,
     addReply,
     loadMoreComments,
+    loadMoreReplies,
     updateMember,
     openPopup,
     closePopup

--- a/src/components/Comment.js
+++ b/src/components/Comment.js
@@ -23,6 +23,9 @@ function EditedInfo({comment}) {
 const Comment = ({updateIsEditing = null, isEditing, ...props}) => {
     const [isInEditMode, setIsInEditMode] = useState(false);
     const [isInReplyMode, setIsInReplyMode] = useState(false);
+    const {admin, avatarSaturation, member, commentsEnabled, dispatchAction} = useContext(AppContext);
+    let comment = props.comment;
+
     useEffect(() => {
         updateIsEditing?.(isInReplyMode || isInEditMode);
     }, [updateIsEditing, isInReplyMode, isInEditMode]);
@@ -34,7 +37,11 @@ const Comment = ({updateIsEditing = null, isEditing, ...props}) => {
         setIsInEditMode(false);
     };
 
-    const toggleReplyMode = () => {
+    const toggleReplyMode = async () => {
+        if (!isInReplyMode) {
+            // First load all the replies before opening the reply model
+            await dispatchAction('loadMoreReplies', {comment, limit: 'all'});
+        }
         setIsInReplyMode(current => !current);
     };
 
@@ -42,8 +49,6 @@ const Comment = ({updateIsEditing = null, isEditing, ...props}) => {
         setIsInReplyMode(false);
     };
 
-    const {admin, avatarSaturation, member, commentsEnabled} = useContext(AppContext);
-    let comment = props.comment;
     const hasReplies = comment.replies && comment.replies.length > 0;
     const isNotPublished = comment.status !== 'published';
     const html = {__html: comment.html};

--- a/src/components/Like.js
+++ b/src/components/Like.js
@@ -37,7 +37,7 @@ function Like(props) {
     return (
         <CustomTag className={`group transition-all duration-50 ease-linear flex font-sans items-center text-sm outline-0 ${props.comment.liked ? 'text-neutral-900 dark:text-[rgba(255,255,255,0.9)]' : 'text-neutral-400 dark:text-[rgba(255,255,255,0.5)]'} ${!props.comment.liked && canLike && 'hover:text-neutral-600'} ${likeCursor}`} onClick={toggleLike}>
             <LikeIcon className={animationClass + ` mr-[6px] ${props.comment.liked ? 'fill-neutral-900 stroke-neutral-900 dark:fill-white dark:stroke-white' : 'stroke-neutral-400 dark:stroke-[rgba(255,255,255,0.5)'} ${!props.comment.liked && canLike && 'group-hover:stroke-neutral-600'} transition duration-50 ease-linear`} />
-            {props.comment.likes_count}
+            {props.comment.count.likes}
         </CustomTag>
     );
 }

--- a/src/components/Replies.js
+++ b/src/components/Replies.js
@@ -7,18 +7,16 @@ const Replies = (props) => {
     const comment = props.comment;
     const {dispatchAction} = useContext(AppContext);
 
-    const repliesLeft = comment.count.replies - comment.replies.length - (comment.appendedReplies?.length ?? 0);
+    const repliesLeft = comment.count.replies - comment.replies.length;
 
     const loadMore = () => {
-        dispatchAction('loadMoreReplies', comment);
+        dispatchAction('loadMoreReplies', {comment});
     };
 
     return (
         <div>
             {comment.replies.map((reply => <Comment comment={reply} parent={comment} key={reply.id} isReply={true} />))}
             {repliesLeft > 0 && <RepliesPagination count={repliesLeft} loadMore={loadMore}/>}
-            {/* When we post a reply, and still need to show pagination above it */}
-            {(comment.appendedReplies ?? []).map((reply => <Comment comment={reply} parent={comment} key={reply.id} isReply={true} />))}
         </div>
     );
 };

--- a/src/components/Replies.js
+++ b/src/components/Replies.js
@@ -1,39 +1,24 @@
-import {useState, useEffect} from 'react';
+import { useContext } from 'react';
+import AppContext from '../AppContext';
 import Comment from './Comment';
 import RepliesPagination from './RepliesPagination';
 
 const Replies = (props) => {
     const comment = props.comment;
+    const {dispatchAction} = useContext(AppContext);
 
-    // Very basic pagination right now
-    const MAX_VISIBLE_INITIAL = 3; // Show 3 first comments
-    const PAGE_LENGTH = 5; // Load 5 extra when clicking more
-    const [visibleReplies, setVisibleReplies] = useState([]);
-
-    // This piece of code detects when new replies have been added to the comment
-    // If that is the case, it makes sure all replies are visible (need design input here)
-    useEffect(function () {
-        setVisibleReplies((_visibleReplies) => {
-            if (_visibleReplies.length === 0) {
-                // Initial load
-                return comment.replies.slice(0, MAX_VISIBLE_INITIAL);
-            } else {
-                return comment.replies.slice(0, comment.replies.length);
-            }
-        });
-    }, [comment.replies]);
-
-    const repliesLeft = comment.replies.length - visibleReplies.length;
+    const repliesLeft = comment.count.replies - comment.replies.length - (comment.appendedReplies?.length ?? 0);
 
     const loadMore = () => {
-        const maxLength = visibleReplies.length + PAGE_LENGTH;
-        setVisibleReplies(comment.replies.slice(0, maxLength));
+        dispatchAction('loadMoreReplies', comment);
     };
 
     return (
         <div>
-            {visibleReplies.map((reply => <Comment comment={reply} parent={comment} key={reply.id} isReply={true} />))}
-            {!!repliesLeft && <RepliesPagination count={repliesLeft} loadMore={loadMore}/>}
+            {comment.replies.map((reply => <Comment comment={reply} parent={comment} key={reply.id} isReply={true} />))}
+            {repliesLeft > 0 && <RepliesPagination count={repliesLeft} loadMore={loadMore}/>}
+            {/* When we post a reply, and still need to show pagination above it */}
+            {(comment.appendedReplies ?? []).map((reply => <Comment comment={reply} parent={comment} key={reply.id} isReply={true} />))}
         </div>
     );
 };

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -124,7 +124,7 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}) {
             firstCommentsLoadedAt = firstCommentsLoadedAt ?? new Date().toISOString();
 
             const filter = encodeURIComponent(`post_id:${postId}+created_at:<=${firstCommentsLoadedAt}`);
-            const order = encodeURIComponent('created_at DESC');
+            const order = encodeURIComponent('created_at DESC, id DESC');
 
             const url = endpointFor({type: 'members', resource: 'comments', params: `?limit=5&order=${order}&filter=${filter}&page=${page}`});
             return makeRequest({
@@ -141,6 +141,25 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}) {
                     throw new Error('Failed to fetch comments');
                 }
             });
+        },
+        async replies({page, commentId, afterReplyId}) {
+            const filter = encodeURIComponent(`id:>${afterReplyId}`);
+            const order = encodeURIComponent('created_at ASC, id ASC');
+
+            const url = endpointFor({type: 'members', resource: `comments/${commentId}/replies`, params: `?limit=5&order=${order}&filter=${filter}`});
+            const res = await makeRequest({
+                url,
+                method: 'GET',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                credentials: 'same-origin'
+            });
+            if (res.ok) {
+                return res.json();
+            } else {
+                throw new Error('Failed to fetch replies');
+            }
         },
         add({comment}) {
             const body = {

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -142,11 +142,11 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}) {
                 }
             });
         },
-        async replies({page, commentId, afterReplyId}) {
+        async replies({page, commentId, afterReplyId, limit}) {
             const filter = encodeURIComponent(`id:>${afterReplyId}`);
             const order = encodeURIComponent('created_at ASC, id ASC');
 
-            const url = endpointFor({type: 'members', resource: `comments/${commentId}/replies`, params: `?limit=5&order=${order}&filter=${filter}`});
+            const url = endpointFor({type: 'members', resource: `comments/${commentId}/replies`, params: `?limit=${limit ?? 5}&order=${order}&filter=${filter}`});
             const res = await makeRequest({
                 url,
                 method: 'GET',


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1723

- Moved usage from likes_count to count.likes
- Implemented real reply pagination based by an ID filter
- The backend now returns the relations correctly when creating new comments, so we don't need to fix them any longer.