### PR TITLE
fix: squash console message when non-json hits iframe

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -207,9 +207,6 @@ export default class App extends React.Component {
             try {
                 data = JSON.parse(event.data);
             } catch (err) {
-                /* eslint-disable no-console */
-                console.error('Error parsing event data', err);
-                /* eslint-enable no-console */
                 return;
             }
 


### PR DESCRIPTION
This just removes a generic console.error, because anytime anything spams some messages to iframes - this one catches it and causes a good deal of spam into the console. Since this error message wasn't prefixed with "[Comments]" it seems like its causing more harm than good.

Fixes: https://github.com/TryGhost/Ghost/issues/15428